### PR TITLE
修复无法在uwsgi环境下在线执行debugtalk代码的问题

### DIFF
--- a/fastrunner/utils/runner.py
+++ b/fastrunner/utils/runner.py
@@ -9,6 +9,8 @@ import tempfile
 from fastrunner.utils import loader
 EXEC = sys.executable
 
+if 'uwsgi' in EXEC:
+    EXEC = os.path.join(os.path.dirname(EXEC), 'python')
 
 class DebugCode(object):
 


### PR DESCRIPTION
使用uwsgi启动时, sys.executable返回的是uwsgi的路径, 无法在线执行debugtalk代码