### PR TITLE
Update docker-compose.md

### DIFF
--- a/docker-compose.md
+++ b/docker-compose.md
@@ -106,11 +106,11 @@ docker-compose up -d
 docker exec -it fastrunner容器id /bin/sh #进入容器内部
 
 # make migrations for fastuser、fastrunner
-python manage.py makemigrations fastrunner fastuser
+python3 manage.py makemigrations fastrunner fastuser
 
 # migrate for database
-python manage.py migrate fastrunner
-python manage.py migrate fastuser
+python3 manage.py migrate fastrunner
+python3 manage.py migrate fastuser
 ```
 ------
 


### PR DESCRIPTION
fastrunner容器被build的时候安装的Python版本为Python3, 所以当进入容器执行Python的时候, 需要使用Python3.  
已经在Ubuntu16.04 server上试验过